### PR TITLE
Fixed Menu bar overlapping content in small mobile views

### DIFF
--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -22,7 +22,7 @@ const Content = styled.div`
   }
 
   @media screen and (max-width: 480px) {
-    padding: 0;
+    padding: 0.5rem 0;
     max-width: 100%;
   }
 `


### PR DESCRIPTION
Added padding to `Content.js` under media query `max-width: 480`

Fixes #58 

![screen shot 2018-08-08 at 9 15 57 am](https://user-images.githubusercontent.com/9542958/43850030-b147b22a-9aeb-11e8-9874-7fce770e0e57.png)
